### PR TITLE
Modify puppeteer launch options for PDF guide

### DIFF
--- a/app/api/generate-guide/route.ts
+++ b/app/api/generate-guide/route.ts
@@ -7,7 +7,10 @@ import puppeteer from 'puppeteer';
 export async function POST(req: NextRequest) {
   const data = await req.json();
 
-  const browser = await puppeteer.launch();
+  const browser = await puppeteer.launch({
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    headless: 'new'
+  });
   const page = await browser.newPage();
 
   const html = `<html><body><h1>${data.title || 'Guía de Automatización'}</h1></body></html>`;


### PR DESCRIPTION
## Summary
- pass sandbox args and `headless: 'new'` to Puppeteer in the generate-guide API route

## Testing
- `npm run lint` *(fails: 403 Forbidden while installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688c7942fa90832caad2b27e81362ba3