### PR TITLE
Load contact form URL from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env.local and update the values as needed
+
+# OpenAI API Key
+OPENAI_API_KEY=your-openai-api-key
+
+# URL for the embedded contact form
+NEXT_PUBLIC_CONTACT_FORM_URL=https://forms.office.com/Pages/ResponsePage.aspx?your-form-id

--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ This starter application uses Next.js and React Server Components. By default, a
 > e to the *out* folder, and start the CLI from the *out* folder.
 
 <!-- trigger deployment -->
+
+## Configuration
+
+Create a `.env.local` file based on the provided `.env.example` and supply the
+required values.
+
+- `OPENAI_API_KEY` &ndash; API key used by the assistant API routes.
+- `NEXT_PUBLIC_CONTACT_FORM_URL` &ndash; URL of the embedded contact form used on
+  the home and contact pages.

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -4,7 +4,7 @@ export default function ContactPage() {
   return (
     <div className="container mx-auto py-8">
       <iframe
-        src="https://forms.office.com/Pages/ResponsePage.aspx?...&embed=true"
+        src={process.env.NEXT_PUBLIC_CONTACT_FORM_URL || ''}
         frameBorder={0}
         marginWidth={0}
         marginHeight={0}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,7 +13,7 @@ export default function Home() {
       {/* Microsoft Forms iframe */}
       <section id="contact" className="py-20">
         <iframe
-          src="https://forms.office.com/Pages/ResponsePage.aspx?..." // TODO: replace
+          src={process.env.NEXT_PUBLIC_CONTACT_FORM_URL || ''}
           width="100%"
           height="600"
           style={{ border: 'none' }}


### PR DESCRIPTION
## Summary
- make the contact form URL configurable via env variables
- document env vars
- provide `.env.example` for setup

## Testing
- `npm run lint` *(fails: missing TypeScript deps)*
- `npm run build` *(fails: cannot fetch fonts due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_688c795cf500832c8125bf29964b17fa