### PR TITLE
Fix generate-guide Response headers

### DIFF
--- a/app/api/generate-guide/route.ts
+++ b/app/api/generate-guide/route.ts
@@ -23,7 +23,7 @@ export async function POST(req: NextRequest) {
     headers: {
       'Content-Type': 'application/pdf',
       'Content-Disposition': 'attachment; filename=simiriki-guide.pdf',
-  },
-});
+    },
+  });
 }
 


### PR DESCRIPTION
## Summary
- correct closing braces in app/api/generate-guide route

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c7ed73c38832c88a9da0d45dba844