### PR TITLE
feat: add chat widget to layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,7 @@
 // app/layout.tsx
+import "./globals.css";
 import { ReactNode } from "react";
+import ChatWidget from "./components/ChatWidget";
 
 export const metadata = {
   title: "Simiriki",
@@ -24,6 +26,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       </head>
       <body style={{ fontFamily: "Roboto, sans-serif" }}>
         {children}
+        <ChatWidget />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- render ChatWidget from root layout so assistant is available site-wide
- include global styles for proper widget styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(prompts for ESLint configuration)*
- `npm run build` *(fails: module is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_6899939e05a8832cb9aaaccc0e305faa