### PR TITLE
docs: add env example and setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example environment variables
+OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -4,10 +4,16 @@
 
 ## Running locally
 
-To run locally, start by installing the Node dependencies. 
+To run locally, start by installing the Node dependencies.
 
 ```bash
 npm install
+```
+
+Copy the example environment file and set your environment variables:
+
+```bash
+cp .env.example .env.local
 ```
 
 Start the development server with the following command:


### PR DESCRIPTION
## Summary
- provide `.env.example` with required environment variables
- document copying `.env.example` to `.env.local` before running the dev server

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for configuration)


------
https://chatgpt.com/codex/tasks/task_e_689993ab2498832c839e47e3f5beccf8